### PR TITLE
[Breaking Change]  prefix the env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,6 @@ jobs:
 ```
 
 By adding this configuration, your Storybook environment variables will be correctly injected during the Chromatic deployment process.
+
+![Example Image - Storybook - Confluence-addon](https://github.com/user-attachments/assets/b261b398-4eee-4b1b-8cb9-6713109fe116)
+

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ export default {
 #### Go to this [link](https://id.atlassian.com/manage-profile/security/api-tokens) and create an API Token for your account. Then add it along with the email for your account to a .env file as so.
 
 ```env
-CONFLUENCE_EMAIL=youremail@example.com
-CONFLUENCE_TOKEN=YourTokenHere!
+STORYBOOK_CONFLUENCE_EMAIL=youremail@example.com
+STORYBOOK_CONFLUENCE_TOKEN=YourTokenHere!
 ```
 
 ### 4. Add a middleware.js file to your .storybook folder, and copy this code to it
@@ -81,3 +81,30 @@ export const myStory = {
   },
 };
 ```
+
+### 7. Injecting Environment Variables in GitHub Actions
+
+Start by adding a new secret to your GitHub repository. Navigate to your repository on GitHub, click on the "Settings" tab, and then click on "Secrets" in the left-hand sidebar. Click on the "New repository secret" button, and add the following secrets:
+
+- `STORYBOOK_CONFLUENCE_EMAIL`: The email address associated with your Confluence account.
+- `STORYBOOK_CONFLUENCE_TOKEN`: The API token generated for your Confluence account.
+
+If you are using Chromatic for deployment and need to inject environment variables into your hosted Storybook, update your .github/workflows/chromatic.yml file as follows:
+
+```yml
+.github/workflows/chromatic.yml
+jobs:
+  chromatic:
+    steps:
+      # ... other steps
+
+      - uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        env:
+          # 👇 Sets the environment variable
+          STORYBOOK_CONFLUENCE_EMAIL: ${{ secrets.STORYBOOK_CONFLUENCE_EMAIL }}
+          STORYBOOK_CONFLUENCE_TOKEN: ${{ secrets.STORYBOOK_CONFLUENCE_TOKEN }}
+```
+
+By adding this configuration, your Storybook environment variables will be correctly injected during the Chromatic deployment process.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from "express";
 require("dotenv").config();
 
 const CONFLUENCE_AUTHORIZATION = Buffer.from(
-  `${process.env.CONFLUENCE_EMAIL}:${process.env.CONFLUENCE_TOKEN}`,
+  `${process.env.STORYBOOK_CONFLUENCE_EMAIL}:${process.env.STORYBOOK_CONFLUENCE_TOKEN}`,
 ).toString("base64");
 
 const fetchPage = async (auth: string, url: string) => {
@@ -26,8 +26,13 @@ const getConfluencePage = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    // Missing authorization handling.
-    const { CONFLUENCE_EMAIL, CONFLUENCE_TOKEN } = process.env;
+    const CONFLUENCE_EMAIL =
+      process.env.STORYBOOK_CONFLUENCE_EMAIL || process.env.CONFLUENCE_EMAIL;
+
+    const CONFLUENCE_TOKEN =
+      process.env.STORYBOOK_CONFLUENCE_TOKEN || process.env.CONFLUENCE_TOKEN;
+
+    // Missing authorization handling
     if (!CONFLUENCE_EMAIL || !CONFLUENCE_TOKEN) {
       res.locals.page =
         !CONFLUENCE_EMAIL && !CONFLUENCE_TOKEN


### PR DESCRIPTION
Per storybooks suggestion, prefixing env variables with "STORYBOOK_" to fix an issue where .env variables are not properly being injected
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.25--canary.11.4c59477.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install addon-confluence@0.0.25--canary.11.4c59477.0
  # or 
  yarn add addon-confluence@0.0.25--canary.11.4c59477.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
