### PR TITLE
Add bin script for fetchDocs command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "dotenv": "^16.4.5"
       },
       "bin": {
-        "fetchDocs": "node ./dist/fetchDocs.js"
+        "fetchDocs": "node ./dist/fetchDocs.cjs"
       },
       "devDependencies": {
         "@storybook/addon-essentials": "8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "dotenv": "^16.4.5"
       },
       "bin": {
-        "fetchDocs": "dist/fetchDocs.js"
+        "fetchDocs": "node ./dist/fetchDocs.js"
       },
       "devDependencies": {
         "@storybook/addon-essentials": "8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "dotenv": "^16.4.5"
       },
       "bin": {
-        "fetchDocs": "node ./dist/fetchDocs.cjs"
+        "fetchDocs": "dist/fetchDocs.cjs"
       },
       "devDependencies": {
         "@storybook/addon-essentials": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "./package.json": "./package.json"
   },
   "bin": {
-    "fetchDocs": "node ./dist/fetchDocs.js"
+    "fetchDocs": "node ./dist/fetchDocs.cjs"
   },
   "files": [
     "dist/**/*",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "./package.json": "./package.json"
   },
   "bin": {
-    "fetchDocs": "dist/fetchDocs.js"
+    "fetchDocs": "node ./dist/fetchDocs.js"
   },
   "files": [
     "dist/**/*",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "./package.json": "./package.json"
   },
   "bin": {
-    "fetchDocs": "node ./dist/fetchDocs.cjs"
+    "fetchDocs": "dist/fetchDocs.cjs"
   },
   "files": [
     "dist/**/*",


### PR DESCRIPTION
This PR adds a bin script to the package.json file, allowing users to directly execute the fetchDocs command from their project's root directory. This simplifies the integration process and enhances the user experience.

Key Changes:

Added a bin section to package.json:
```
"bin": {
  "fetchDocs": "node ./dist/fetchDocs.js"
}
```
With this change, users can now add fetchDocs to their project's scripts section and execute it directly:
```
"scripts": {
  "prebuild-storybook": "fetchDocs"
}
```